### PR TITLE
Update io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -1,5 +1,5 @@
 {
-  "common": {
+  "wallpanel": {
     "name": "wallpanel",
     "version": "0.3.8",
     "news": {


### PR DESCRIPTION
Now the RAW of this file can be entered as repository in ioBroker. The adapter can thus be installed as an adapter via the ioBroker WebGUI --> Adapter without any problems.